### PR TITLE
Include mpclient-demo in mplane_client build

### DIFF
--- a/mplane_client/CMakeLists.txt
+++ b/mplane_client/CMakeLists.txt
@@ -59,7 +59,7 @@ file (GLOB_RECURSE MPC_TESTER_SRC test/*.cpp)
 add_executable (${MPC_TESTER} ${MPC_TESTER_SRC} ${MPC_IF_SRC})
 target_link_libraries (${MPC_TESTER} ${MPC_LIBS})
 
-file (GLOB MPCLIENT_DEMO_SOURCES src/demo/*.cpp)
+file (GLOB MPCLIENT_DEMO_SOURCES example/*.cpp)
 add_executable (${Target_mpclient_demo} ${MPCLIENT_DEMO_SOURCES} ${MPC_IF_SRC})
 target_link_libraries (${Target_mpclient_demo} ${Target_mpclient_client} ${MPC_LIBS})
 

--- a/mplane_client/CMakeLists.txt
+++ b/mplane_client/CMakeLists.txt
@@ -61,7 +61,12 @@ target_link_libraries (${MPC_TESTER} ${MPC_LIBS})
 
 file (GLOB MPCLIENT_DEMO_SOURCES example/*.cpp)
 add_executable (${Target_mpclient_demo} ${MPCLIENT_DEMO_SOURCES} ${MPC_IF_SRC})
-target_link_libraries (${Target_mpclient_demo} ${Target_mpclient_client} ${MPC_LIBS})
+
+file (GLOB RPC_CLIENT_SOURCES test/rpc-client/*.cpp)
+target_sources (${Target_mpclient_demo} PRIVATE ${RPC_CLIENT_SOURCES})
+
+target_link_libraries (${Target_mpclient_demo} ${MPC_LIBS})
+
 
 # Copy test cases files when they are modified
 file (GLOB MPC_TESTS_CASES test/tests/cases/*)

--- a/mplane_client/CMakeLists.txt
+++ b/mplane_client/CMakeLists.txt
@@ -7,7 +7,7 @@ project (MPLANE_CLIENT CXX)
 
 set (MPC_CLIENT mpc_client)
 set (MPC_TESTER mpc_tester)
-# set (Target_mpclient_demo mpclient-demo)
+set (Target_mpclient_demo mpclient-demo)
 
 find_program (PROTOC protoc PATHS deps/install/bin)
 find_program (GRPC_CPP_PLUGIN grpc_cpp_plugin PATHS deps/install/bin)
@@ -59,9 +59,9 @@ file (GLOB_RECURSE MPC_TESTER_SRC test/*.cpp)
 add_executable (${MPC_TESTER} ${MPC_TESTER_SRC} ${MPC_IF_SRC})
 target_link_libraries (${MPC_TESTER} ${MPC_LIBS})
 
-# file (GLOB MPCLIENT_DEMO_SOURCES src/demo/*.cpp)
-# add_executable (${Target_mpclient_demo} ${MPCLIENT_DEMO_SOURCES} ${MPC_IF_SRC})
-# target_link_libraries (${Target_mpclient_demo} ${Target_mpclient_client} ${MPC_LIBS})
+file (GLOB MPCLIENT_DEMO_SOURCES src/demo/*.cpp)
+add_executable (${Target_mpclient_demo} ${MPCLIENT_DEMO_SOURCES} ${MPC_IF_SRC})
+target_link_libraries (${Target_mpclient_demo} ${Target_mpclient_client} ${MPC_LIBS})
 
 # Copy test cases files when they are modified
 file (GLOB MPC_TESTS_CASES test/tests/cases/*)

--- a/mplane_client/example/README.md
+++ b/mplane_client/example/README.md
@@ -13,7 +13,7 @@ and executes the corresponding mpclient RPC.
 ## Usage
 ```
 ./wrapper.sh ./mpclient-demo \
-  --commands demo/cases/connect.json \
+  --commands ../example/cases/connect.json \
   --netconfHost 192.168.10.13 \
   --netconfUser oran \
   --netconfPassword Password123 \

--- a/mplane_client/test/docker/test.integrated.Dockerfile
+++ b/mplane_client/test/docker/test.integrated.Dockerfile
@@ -18,6 +18,7 @@ RUN patch --directory /opt/dev/ntsim-ng/config/ --strip 4 config.json config.pat
 COPY src /mplane_client/src
 COPY test/rpc-client /mplane_client/test/rpc-client
 COPY test/tests /mplane_client/test/tests
+COPY example /mplane_client/example
 
 WORKDIR /mplane_client/utils
 RUN ./build_mpclient.sh --parallel 2


### PR DESCRIPTION
The mpclient-demo CLI has been integrated into the mplane_client build, both CMake and dockerized. mpclient-demo can be used to send commands to the mplane-server. To achieve this, the CMakeLists.txt file for the mplane_client has been updated to include the mpclient-demo and its dependency. The Dockerfile for the integrated-tester that adds pre-built binaries for mplane_client has also been updated to include the demo client. The README now contains the command with the correct path for command files.